### PR TITLE
fix-copysign-mps-scalar-promotion

### DIFF
--- a/aten/src/ATen/native/mps/OperationUtils.mm
+++ b/aten/src/ATen/native/mps/OperationUtils.mm
@@ -1027,6 +1027,9 @@ void MetalShaderLibrary::exec_binary_kernel(TensorIteratorBase& iter,
 
   Tensor input = iter.input(0);
   Tensor other = iter.input(1);
+  if (other.device() != input.device()) {
+     other = other.to(input.device());    //This ensures that in torch.copysign(t_mps, -2.0), the scalar is moved to MPS 
+  }
   Tensor out = iter.output();
 
   id<MTLDevice> device = MPSDevice::getInstance()->device();


### PR DESCRIPTION
**PR Summary**

This PR fixes an inconsistency in torch.copysign on the MPS backend when used with a scalar as the second operand. Scalars were being promoted to CPU tensors by default, leading to incorrect results due to cross-device operations.

Repro Before Fix

import torch
t = torch.tensor([1.0, 2.0, 3.0], device="mps")
torch.copysign(t, -2.0)
# Returns: tensor([1., 2., 3.], device='mps:0')

Expected After Fix

# Correct output:
tensor([-1., -2., -3.], device='mps:0')

The fix ensures that scalars are promoted to the same device (input.device()) in exec_binary_kernel, aligning behavior across backends and preventing silent failures.

**Related Issue**

This addresses the issue discussed in [pytorch#152582] [(link to the original GitHub issue if there is one).](https://github.com/pytorch/pytorch/issues/152582)

**CC Maintainers**

@malfet @albanD @kulinseth @DenisVieriu97
Please review: this is a small but important fix to maintain consistency and correctness in binary ops on MPS.
